### PR TITLE
Genetic Rim Cosmic Horror Patch

### DIFF
--- a/Patches/Genetic Rim/GeneticRim_Races_CE/Races_Animal_CosmicHorrors_HybridCE.xml
+++ b/Patches/Genetic Rim/GeneticRim_Races_CE/Races_Animal_CosmicHorrors_HybridCE.xml
@@ -1,0 +1,515 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+		<li>GeneticRim Cosmic Horrors Patch</li>
+		</mods>
+
+		<match Class="PatchOperationSequence">
+			<operations>
+	
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_EldritchBear"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Quadruped</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_EldritchBear"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.15</MeleeDodgeChance>
+				<MeleeCritChance>0.51</MeleeCritChance>
+				<MeleeParryChance>0.25</MeleeParryChance>
+				<ArmorRating_Blunt>0.5</ArmorRating_Blunt>
+				<ArmorRating_Sharp>0.25</ArmorRating_Sharp>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_EldritchBear"]/tools</xpath>
+				<value>
+		<tools>
+            <li Class="CombatExtended.ToolCE">
+              <label>hooves</label>
+              <capacities>
+                <li>ROM_BluntMonstrous</li>
+              </capacities>
+              <power>17</power>
+              <cooldownTime>1.55</cooldownTime>
+              <linkedBodyPartsGroup>ROM_Hooves</linkedBodyPartsGroup>
+              <armorPenetrationBlunt>15.6</armorPenetrationBlunt>
+              <chanceFactor>0.2</chanceFactor>
+            </li>
+            <li Class="CombatExtended.ToolCE">
+              <label>tentacles</label>
+              <capacities>
+                <li>ROM_BluntMonstrous</li>
+              </capacities>
+              <power>21</power>
+              <cooldownTime>1.45</cooldownTime>
+              <linkedBodyPartsGroup>ROM_Tentacles</linkedBodyPartsGroup>
+              <armorPenetrationBlunt>14.8</armorPenetrationBlunt>
+            </li>
+            <li Class="CombatExtended.ToolCE">
+              <label>coiling tentacles</label>
+              <capacities>
+                <li>ROM_ConstrictMonstrous</li>
+              </capacities>
+              <power>16</power>
+              <cooldownTime>1.65</cooldownTime>
+              <linkedBodyPartsGroup>ROM_Tentacles</linkedBodyPartsGroup>
+              <armorPenetrationBlunt>28.8</armorPenetrationBlunt>
+              <chanceFactor>0.5</chanceFactor>
+            </li>
+            <li Class="CombatExtended.ToolCE">
+              <label>maw</label>
+              <capacities>
+                <li>ToxicBite</li>
+              </capacities>
+              <power>31</power>
+              <cooldownTime>1.75</cooldownTime>
+              <linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+              <armorPenetrationSharp>5</armorPenetrationSharp>
+              <armorPenetrationBlunt>12.6</armorPenetrationBlunt>
+              <chanceFactor>0.33</chanceFactor>
+            </li>
+					</tools>
+				</value>
+			</li>
+			
+			<!-- Boomspawn -->
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_EldritchBoomalope"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Humanoid</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_EldritchBoomalope"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.13</MeleeDodgeChance>
+				<MeleeCritChance>0.27</MeleeCritChance>
+				<MeleeParryChance>0.24</MeleeParryChance>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_EldritchBoomalope"]/race/baseHealthScale</xpath>
+				<value>
+					<baseHealthScale>3.8</baseHealthScale>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_EldritchBoomalope"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>amoebic tentacle</label>
+							<capacities>
+								<li>GR_VeryToxicBite</li>
+							</capacities>
+							<power>17</power>
+							<cooldownTime>1.02</cooldownTime>
+							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+				<surpriseAttack>
+					<extraMeleeDamages>
+						<li>
+							<def>Stun</def>
+							<amount>10</amount>
+						</li>
+					</extraMeleeDamages>
+				</surpriseAttack>
+							<armorPenetrationSharp>3</armorPenetrationSharp>
+							<armorPenetrationBlunt>6</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>15</power>
+							<cooldownTime>1.45</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>8</armorPenetrationBlunt>
+							<chanceFactor>0.25</chanceFactor>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<!-- EldritchChickens -->
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_EldritchChicken"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>QuadrupedLow</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_EldritchChicken"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.5</MeleeDodgeChance>
+				<MeleeCritChance>0.03</MeleeCritChance>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_EldritchChicken"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+						<label>overwhelming mind</label>
+							<capacities>
+								<li>ROM_Psychic</li>
+							</capacities>
+							<power>10</power>
+							<cooldownTime>0.55</cooldownTime>
+							<linkedBodyPartsGroup>ROM_Mind</linkedBodyPartsGroup>
+							<armorPenetrationSharp>100</armorPenetrationSharp>
+							<armorPenetrationBlunt>150</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+				                                                <label>head</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>2</power>
+							<cooldownTime>1</cooldownTime>
+							<linkedBodyPartsGroup>ROM_Wings</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>0.25</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_EldritchInsectoid"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>QuadrupedLow</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_EldritchInsectoid"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.1</MeleeDodgeChance>
+				<MeleeCritChance>0.18</MeleeCritChance>
+				<MeleeParryChance>0.2</MeleeParryChance>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_EldritchInsectoid"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>1.5</ArmorRating_Blunt>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_EldritchInsectoid"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>1</ArmorRating_Sharp>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_EldritchInsectoid"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>overwhelming mind</label>
+							<capacities>
+							<li>ROM_Psychic</li>
+							</capacities>
+							<power>18</power>
+							<cooldownTime>1.18</cooldownTime>
+							<linkedBodyPartsGroup>ROM_Mind</linkedBodyPartsGroup>
+							<armorPenetrationSharp>200</armorPenetrationSharp>
+							<armorPenetrationBlunt>200</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>grasping tentacles</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>10</power>
+							<cooldownTime>1.36</cooldownTime>
+							<linkedBodyPartsGroup>ROM_Tentacles</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>4</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>mandibles</label>
+							<capacities>
+							<li>Cut</li>
+							</capacities>
+							<power>21</power>
+							<cooldownTime>1.48</cooldownTime>
+							<linkedBodyPartsGroup>ROM_Mind</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.9</armorPenetrationSharp>
+							<armorPenetrationBlunt>2</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_EldritchMuffalo"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Quadruped</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_EldritchMuffalo"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.1</MeleeDodgeChance>
+				<MeleeCritChance>0.47</MeleeCritChance>
+				<MeleeParryChance>0.5</MeleeParryChance>
+				</value>
+			</li>
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_EldritchMuffalo"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+						<label>vampiric teeth</label>
+						<capacities>
+							<li>ROM_Exsanguination</li>
+						</capacities>
+						<power>28</power>
+						<cooldownTime>1.56</cooldownTime>
+						<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+						<surpriseAttack>
+						<extraMeleeDamages>
+						<li>
+							<def>Stun</def>
+							<amount>10</amount>
+						</li>
+						</extraMeleeDamages>
+						</surpriseAttack>
+						<armorPenetrationSharp>10</armorPenetrationSharp>
+						<armorPenetrationBlunt>4</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<capacities>
+								<li>Cut</li>
+							</capacities>
+							<power>18</power>
+							<cooldownTime>1.25</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationSharp>2.5</armorPenetrationSharp>
+							<armorPenetrationBlunt>5</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<!-- EldritchSnak -->
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_EldritchReptile"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Serpentine</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_EldritchReptile"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.5</MeleeDodgeChance>
+				<MeleeCritChance>0.04</MeleeCritChance>
+				<MeleeParryChance>0.1</MeleeParryChance>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_EldritchReptile"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<capacities>
+					                                                 <li>ToxicBite</li>
+							</capacities>
+							<power>6</power>
+							<cooldownTime>0.25</cooldownTime>
+							<linkedBodyPartsGroup>Mouth</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>7</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>0.25</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.25</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>2</power>
+							<cooldownTime>0.3</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>0.25</armorPenetrationBlunt>
+							<chanceFactor>0.1</chanceFactor>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_EldritchThrumbo"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>BirdLike</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_EldritchThrumbo"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.25</MeleeDodgeChance>
+				<MeleeCritChance>0.84</MeleeCritChance>
+				<MeleeParryChance>0.45</MeleeParryChance>
+				</value>
+			</li>
+
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_EldritchThrumbo"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>14</ArmorRating_Sharp>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_EldritchThrumbo"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>22</ArmorRating_Blunt>
+				</value>
+			</li>
+
+		                 <li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="GR_EldritchThrumbo"]/race/baseHealthScale</xpath>
+					<value>
+						<baseHealthScale>10</baseHealthScale>
+					</value>
+		                </li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_EldritchThrumbo"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+								<label>rending claws</label>
+								<capacities>
+									<li>Cut</li><li>Stab</li>
+								</capacities>
+								<power>45</power>
+								<cooldownTime>1</cooldownTime>
+								<linkedBodyPartsGroup>ROM_RightClaws</linkedBodyPartsGroup>
+								<armorPenetrationSharp>14</armorPenetrationSharp>
+								<armorPenetrationBlunt>32</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>mandibles</label>
+							<capacities>
+								<li>Bite</li><li>Stab</li>
+							</capacities>
+							<power>40</power>
+							<cooldownTime>1.28</cooldownTime>
+							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+							<armorPenetrationSharp>24</armorPenetrationSharp>
+							<armorPenetrationBlunt>52</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>20</power>
+							<cooldownTime>2.78</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>20</armorPenetrationBlunt>
+				                                                <chanceFactor>0.2</chanceFactor>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_EldritchWolf"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Quadruped</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_EldritchWolf"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>1</MeleeDodgeChance>
+				<MeleeCritChance>0.21</MeleeCritChance>
+				<MeleeParryChance>0.33</MeleeParryChance>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_EldritchWolf"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>14</ArmorRating_Sharp>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_EldritchThrumbo"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>32</ArmorRating_Blunt>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_EldritchWolf"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+						<label>venomous fangs</label>
+						<capacities>
+							<li>ToxicBite</li>
+						</capacities>
+						<power>28</power>
+						<cooldownTime>1.25</cooldownTime>
+						<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+						<armorPenetrationSharp>5</armorPenetrationSharp>
+						<armorPenetrationBlunt>10</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+						<label>claws</label>
+						<capacities>
+							<li>Cut</li>
+						</capacities>
+						<power>15</power>
+						<cooldownTime>0.75</cooldownTime>
+						<linkedBodyPartsGroup>Feet</linkedBodyPartsGroup>
+						<armorPenetrationSharp>1.5</armorPenetrationSharp>
+						<armorPenetrationBlunt>3</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+			</operations>
+		</match>
+	</Operation>
+</Patch>


### PR DESCRIPTION
## Additions

All animals and materials patched.

## Changes

Describe adjustments to existing features made in this merge, e.g.
- Increased regular smoke bomb radius

## References

Links to the associated issues or other related pull requests, e.g.
- Closes #[ISSUE_NUMBER]
- Contributes towards #[ISSUE_NUMBER]

## Reasoning

Why did you choose to implement things this way, e.g.
- Tribals need ways to close distance with pirate raiders
- Smoke bombs allow this while enhancing combat micro
- Thematically appropriate as we already allow tribal prometheum handling
- Easy to implement
- Buffed regular smoke grenades as they are rarely utilized and to justify additional investment

## Alternatives

Describe alternative implementations you have considered, e.g.
- Tribal catapult that launches melee animals into siege camps:
  - Additional use for animals
  - Anachronistic
  - Breaks realism theme

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
